### PR TITLE
add error handling specific to their api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,7 @@ let executeHttp = exports.executeHttp = function executeHttp(httpMethod, path, d
       }
       
       if (body.error){
-        throw new Error(body.error_description)
+        reject(new Error(body.error_description))
       }
       resolve(body);
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,7 +71,10 @@ let executeHttp = exports.executeHttp = function executeHttp(httpMethod, path, d
 
         return;
       }
-
+      
+      if (body.error){
+        throw new Error(body.error_description)
+      }
       resolve(body);
     }
   });


### PR DESCRIPTION
they don't use http statuses for errors, instead using the error, and error_dsecription params in the body.