### PR TITLE
SDK doesn't refresh token

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -48,7 +48,7 @@ let executeHttp = exports.executeHttp = function executeHttp(httpMethod, path, d
   return new promise((resolve, reject) => {
     let httpOptions = {};
 
-    if(!('access_token' in tokenPersist) && utils.hasTokenExpired(tokenPersist)) {
+    if(!('access_token' in tokenPersist) || utils.hasTokenExpired(tokenPersist)) {
       generateToken()
         .then(() => {
           invoke();


### PR DESCRIPTION
If a token has expired the SDK won't generate a new one, this fixes the issue.